### PR TITLE
fix: initialize animation timers

### DIFF
--- a/components/particle-system.tsx
+++ b/components/particle-system.tsx
@@ -25,7 +25,7 @@ export function ParticleSystem({
 }: ParticleSystemProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const particlesRef = useRef<Particle[]>([])
-  const animationRef = useRef<number>()
+  const animationRef = useRef<number | null>(null)
 
   useEffect(() => {
     const canvas = canvasRef.current

--- a/hooks/use-optimized-scroll.ts
+++ b/hooks/use-optimized-scroll.ts
@@ -20,7 +20,7 @@ export function useOptimizedScroll() {
 
   const lastScrollY = useRef(0)
   const lastTimestamp = useRef(0)
-  const scrollTimeout = useRef<NodeJS.Timeout>()
+  const scrollTimeout = useRef<NodeJS.Timeout | null>(null)
   const { addAnimation } = useAnimationManager()
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- initialize animationRef and scrollTimeout to avoid undefined values

## Testing
- `pnpm exec tsc -p tsconfig.json --noEmit` *(fails: Type 'RefObject<HTMLElement | null>' is not assignable to type 'Ref<HTMLDivElement> | undefined'.)*
- `pnpm lint` *(fails: Command failed with exit code 1.)*
- `pnpm run test` *(fails: Missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_6896fb57f3a08333bfc60728ffeb9c43