### PR TITLE
test: add cn utility tests

### DIFF
--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -1,0 +1,24 @@
+import { test } from 'node:test'
+import assert from 'node:assert'
+import { cn } from './utils'
+
+test('merges overlapping Tailwind classes', () => {
+  assert.strictEqual(cn('px-2', 'px-4'), 'px-4')
+})
+
+test('handles multiple classnames', () => {
+  assert.strictEqual(
+    cn('text-sm', 'text-lg', 'font-bold', 'px-2', 'px-4'),
+    'text-lg font-bold px-4'
+  )
+})
+
+test('handles conditional classes', () => {
+  const condition = false
+  assert.strictEqual(cn('p-2', condition && 'p-4'), 'p-2')
+  assert.strictEqual(cn('p-2', { 'p-4': true }), 'p-4')
+})
+
+test('returns empty string for no input', () => {
+  assert.strictEqual(cn(), '')
+})

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "build": "next build",
     "dev": "next dev",
     "lint": "next lint",
-    "start": "next start"
+    "start": "next start",
+    "test": "tsc lib/utils.test.ts --module commonjs --target es2019 --esModuleInterop --moduleResolution node --skipLibCheck --outDir dist-tests && node --test dist-tests/utils.test.js && rm -rf dist-tests"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",


### PR DESCRIPTION
## Summary
- add node-based tests for cn class merging helper
- run tests via tsc compilation and node test runner

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6897009fcf5c8333807e369bbe1c5e0c